### PR TITLE
Made it work without a package.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 This package is a [shareable configuration](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/shareable-configurations.md) for [semantic-release](https://github.com/semantic-release/semantic-release) that:
 
-- configures `tagFormat` to use the package name from the current directory `${package.name}-v${version}`
 - uses `commits` only applicable to the current directory
 
 ## :question: Why
@@ -34,9 +33,9 @@ Now we can run `semantic-release` in any of the package directories and/or in th
 Make sure that if you have `semantic-version` installed globally, also install `semantic-version-commit-filter` globally. Same with local install.
 
 ```console
-$ npm install --dev semantic-version-commit-filter
+$ npm install --dev semantic-release-commit-filter
 
-$ yarn install --dev semantic-version-commit-filter
+$ yarn install --dev semantic-release-commit-filter
 ```
 
 > **!!** make sure you make `semantic-release` available in every `package.json` file. Additionally, every package directory needs its own semantic release configuration file.
@@ -47,6 +46,7 @@ You can either specify this packages in your [release config file](https://githu
 
 ```json
 {
+  "tagFormat": "FOLDER_NAME/${version}",
   "extends": ["semantic-release-commit-filter"]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ You can either specify this packages in your [release config file](https://githu
 or specify it as a paramater to the `semantic-release` cli
 
 ```shell
-$ npx semantic-release -e semantic-release-commit-filter
+$ npx semantic-release -e semantic-release-commit-filter -t 'FOLDER_NAME/${version}'
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,3 @@ Object.keys(require.cache)
       return parse(config, options)
     }
   })
-
-export const tagFormat = `${
-  require(posix.resolve(process.cwd(), "package.json")).name
-}-v\${version}`


### PR DESCRIPTION
Shouldn't the tagFormat also come from the releaserc file or the command line rather than coming from the package?

If it comes from releaserc file or command line, it can then support projects that don't use a package.json file.

I noticed without a package.json it sliently fails with below error:

<img width="726" alt="image" src="https://github.com/folke/semantic-release-commit-filter/assets/10074427/ed466942-e3fb-48e2-9601-bf69eb656d0d">

with DEBUG=*, you can see the failure

<img width="793" alt="image" src="https://github.com/folke/semantic-release-commit-filter/assets/10074427/2f9afa2b-455a-4ce7-890f-38d9fce37d61">

